### PR TITLE
- Fixed the Heatmap renderer.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -5,7 +5,14 @@
   <meta charset="utf-8">
   <title>Csvlayer</title>
   <base href="/">
+  <script>
+    var dojoConfig = {
+      has: {
+        "esri-featurelayer-webgl": 1
+      }
+    };
 
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" href="https://js.arcgis.com/4.8/esri/css/main.css">


### PR DESCRIPTION
The HeatmapRenderer only works with WebGL-enabled FeatureLayer, and at version 4.8 one of the limitations for WebGL-support is listed as:

> Layers created from feature collections or client-side graphics are not supported. https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#webgl-rendering

This limitation should hopefully go away at the next release (version 4.9).

https://community.esri.com/message/794095-csvlayer-doesnt-show-heatmap-in-angular-6